### PR TITLE
Implement basic auth and mobile auth flow

### DIFF
--- a/core-svc/internal/service/token/service.go
+++ b/core-svc/internal/service/token/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -19,6 +20,15 @@ type TokenService struct {
 	Config *config.CoreConfig
 }
 
+type ctxKey string
+
+const ContextUserIDKey ctxKey = "userID"
+
+func UserIDFromContext(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(ContextUserIDKey).(uuid.UUID)
+	return id, ok
+}
+
 func NewTokenService(config *config.CoreConfig) *TokenService {
 	return &TokenService{
 		Config: config,
@@ -31,12 +41,40 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
+type RefreshClaims struct {
+	AuthTokenData
+	TokenType string `json:"typ"`
+	jwt.RegisteredClaims
+}
+
 // GenerateToken creates a JWT signed token and returns it with the expiration unix time
 func (t *TokenService) GenerateToken(data AuthTokenData) (string, int64, error) {
 	claims := Claims{
 		AuthTokenData: data,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	secret := []byte(t.Config.AuthSecret)
+
+	signedToken, err := token.SignedString(secret)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return signedToken, claims.ExpiresAt.Unix(), nil
+}
+
+// GenerateRefreshToken creates a signed refresh token with longer expiration
+func (t *TokenService) GenerateRefreshToken(data AuthTokenData) (string, int64, error) {
+	claims := RefreshClaims{
+		AuthTokenData: data,
+		TokenType:     "refresh",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour * 30)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
 	}
@@ -88,6 +126,27 @@ func (t *TokenService) ValidateToken(tokenString string) error {
 	return err
 }
 
+func (t *TokenService) ValidateRefreshToken(tokenString string) error {
+	secret := []byte(t.Config.AuthSecret)
+
+	token, err := jwt.ParseWithClaims(tokenString, &RefreshClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return secret, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	claims, ok := token.Claims.(*RefreshClaims)
+	if !ok || !token.Valid || claims.TokenType != "refresh" {
+		return errors.New("invalid refresh token")
+	}
+
+	return nil
+}
+
 // ExtractTokenData parses the token string and extracts AuthTokenData from claims
 func (t *TokenService) ExtractTokenData(tokenString string) (AuthTokenData, error) {
 	secret := []byte(t.Config.AuthSecret)
@@ -108,6 +167,31 @@ func (t *TokenService) ExtractTokenData(tokenString string) (AuthTokenData, erro
 	}
 
 	// Ensure ID is valid UUID
+	if claims.AuthTokenData.ID == uuid.Nil {
+		return AuthTokenData{}, errors.New("token missing user ID")
+	}
+
+	return claims.AuthTokenData, nil
+}
+
+func (t *TokenService) ExtractRefreshTokenData(tokenString string) (AuthTokenData, error) {
+	secret := []byte(t.Config.AuthSecret)
+
+	token, err := jwt.ParseWithClaims(tokenString, &RefreshClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return secret, nil
+	})
+	if err != nil {
+		return AuthTokenData{}, err
+	}
+
+	claims, ok := token.Claims.(*RefreshClaims)
+	if !ok || !token.Valid || claims.TokenType != "refresh" {
+		return AuthTokenData{}, errors.New("invalid refresh token")
+	}
+
 	if claims.AuthTokenData.ID == uuid.Nil {
 		return AuthTokenData{}, errors.New("token missing user ID")
 	}

--- a/core-svc/internal/service/token/service.go
+++ b/core-svc/internal/service/token/service.go
@@ -3,6 +3,8 @@ package service
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/config"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -29,28 +31,27 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
-// GenerateToken creates a JWT token signed with HS256 and includes user ID and expiry
-//func (t *TokenService) GenerateToken(data AuthTokenData) (string, error) {
-//	claims := Claims{
-//		AuthTokenData: data,
-//		RegisteredClaims: jwt.RegisteredClaims{
-//			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(t.Config.AuthTokenLifespanHours) * time.Hour)),
-//			IssuedAt:  jwt.NewNumericDate(time.Now()),
-//			// Optional: add Issuer, Subject, etc.
-//
-//		},
-//	}
-//
-//	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-//	secret := []byte(t.Config.AuthSecret)
-//
-//	signedToken, err := token.SignedString(secret)
-//	if err != nil {
-//		return "", err
-//	}
-//
-//	return signedToken, nil
-//}
+// GenerateToken creates a JWT signed token and returns it with the expiration unix time
+func (t *TokenService) GenerateToken(data AuthTokenData) (string, int64, error) {
+	claims := Claims{
+		AuthTokenData: data,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	secret := []byte(t.Config.AuthSecret)
+
+	signedToken, err := token.SignedString(secret)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return signedToken, claims.ExpiresAt.Unix(), nil
+}
+
 //
 //// ExtractToken extracts the Bearer token string from the "Authorization" header
 //func (t *TokenService) ExtractToken(c context.Context) string {

--- a/core-svc/internal/transport/auth/handler.go
+++ b/core-svc/internal/transport/auth/handler.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+
+	"github.com/google/uuid"
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/service/auth"
 
 	"connectrpc.com/connect"
@@ -35,27 +37,38 @@ func (h *handler) Register(
 	ctx context.Context,
 	req *connect.Request[mmv1.RegisterRequest],
 ) (*connect.Response[mmv1.Tokens], error) {
-	//panic("implement me")
-	err := h.svc.Register(ctx, req.Msg.Name, req.Msg.Email, req.Msg.Password)
+	tokens, err := h.svc.Register(ctx, req.Msg.Name, req.Msg.Email, req.Msg.Password)
 	if err != nil {
-		return nil, err // propagate as Connect error
+		return nil, err
 	}
-
-	return connect.NewResponse(&mmv1.Tokens{}), nil
+	return connect.NewResponse(&mmv1.Tokens{
+		RefreshToken: tokens.RefreshToken,
+		AccessToken:  tokens.AccessToken,
+		ExpiresAt:    tokens.ExpiresAt,
+	}), nil
 }
 
 func (h *handler) Profile(
 	ctx context.Context,
 	req *connect.Request[mmv1.Empty],
 ) (*connect.Response[mmv1.UserProfile], error) {
-	panic("implement me")
-	return connect.NewResponse(&mmv1.UserProfile{}), nil
+	profile, err := h.svc.Profile(ctx, uuid.Nil)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&mmv1.UserProfile{
+		Id:    profile.ID.String(),
+		Name:  profile.Name,
+		Email: profile.Email,
+	}), nil
 }
 
 func (h *handler) Logout(
 	ctx context.Context,
 	req *connect.Request[mmv1.Empty],
 ) (*connect.Response[mmv1.Empty], error) {
-	panic("implement me")
+	if err := h.svc.Logout(ctx, uuid.Nil); err != nil {
+		return nil, err
+	}
 	return connect.NewResponse(&mmv1.Empty{}), nil
 }

--- a/core-svc/internal/transport/auth/handler.go
+++ b/core-svc/internal/transport/auth/handler.go
@@ -2,9 +2,12 @@ package auth
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/service/auth"
+	token "github.com/yatochka-dev/motion-mint/core-svc/internal/service/token"
+	"github.com/yatochka-dev/motion-mint/core-svc/internal/transport/interceptor"
 
 	"connectrpc.com/connect"
 	mmv1 "github.com/yatochka-dev/motion-mint/core-svc/gen/go/v1"
@@ -13,7 +16,8 @@ import (
 
 type handler struct{ svc auth.Service }
 
-func New(svc auth.Service, opts ...connect.HandlerOption) mmv1c.AuthServiceHandler {
+func New(svc auth.Service, tokens *token.TokenService, opts ...connect.HandlerOption) mmv1c.AuthServiceHandler {
+	opts = append(opts, connect.WithInterceptors(interceptor.Auth(tokens)))
 	return &handler{svc: svc}
 }
 
@@ -48,11 +52,30 @@ func (h *handler) Register(
 	}), nil
 }
 
+func (h *handler) Refresh(
+	ctx context.Context,
+	req *connect.Request[mmv1.RefreshRequest],
+) (*connect.Response[mmv1.Tokens], error) {
+	tokens, err := h.svc.Refresh(ctx, req.Msg.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&mmv1.Tokens{
+		RefreshToken: tokens.RefreshToken,
+		AccessToken:  tokens.AccessToken,
+		ExpiresAt:    tokens.ExpiresAt,
+	}), nil
+}
+
 func (h *handler) Profile(
 	ctx context.Context,
 	req *connect.Request[mmv1.Empty],
 ) (*connect.Response[mmv1.UserProfile], error) {
-	profile, err := h.svc.Profile(ctx, uuid.Nil)
+	id, ok := token.UserIDFromContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("missing user"))
+	}
+	profile, err := h.svc.Profile(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -65,9 +88,13 @@ func (h *handler) Profile(
 
 func (h *handler) Logout(
 	ctx context.Context,
-	req *connect.Request[mmv1.Empty],
+	req *connect.Request[mmv1.LogoutRequest],
 ) (*connect.Response[mmv1.Empty], error) {
-	if err := h.svc.Logout(ctx, uuid.Nil); err != nil {
+	id, ok := token.UserIDFromContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("missing user"))
+	}
+	if err := h.svc.Logout(ctx, id, req.Msg.RefreshToken); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&mmv1.Empty{}), nil

--- a/core-svc/internal/transport/interceptor/auth.go
+++ b/core-svc/internal/transport/interceptor/auth.go
@@ -1,0 +1,37 @@
+package interceptor
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"connectrpc.com/connect"
+	token "github.com/yatochka-dev/motion-mint/core-svc/internal/service/token"
+)
+
+func Auth(tokens *token.TokenService) connect.UnaryInterceptorFunc {
+	return connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				procedure := req.Spec().Procedure
+				if procedure != "/motionmint.v1.AuthService/Profile" && procedure != "/motionmint.v1.AuthService/Logout" {
+					return next(ctx, req)
+				}
+				authHeader := req.Header().Get("Authorization")
+				if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+					return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("missing token"))
+				}
+				tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+				if err := tokens.ValidateToken(tokenStr); err != nil {
+					return nil, connect.NewError(connect.CodeUnauthenticated, err)
+				}
+				data, err := tokens.ExtractTokenData(tokenStr)
+				if err != nil {
+					return nil, connect.NewError(connect.CodeUnauthenticated, err)
+				}
+				ctx = context.WithValue(ctx, token.ContextUserIDKey, data.ID)
+				return next(ctx, req)
+			}
+		},
+	)
+}

--- a/core-svc/main.go
+++ b/core-svc/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/config"
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/db/repository"
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/service/auth"
+	tokenservice "github.com/yatochka-dev/motion-mint/core-svc/internal/service/token"
 	transportAuth "github.com/yatochka-dev/motion-mint/core-svc/internal/transport/auth"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -32,7 +33,8 @@ func main() {
 	d := repo.Test(ctx)
 	fmt.Println(d)
 	/* -------------- AUTH SERVICE ----------------*/
-	authSvc := auth.NewService(repo)
+	tokenSvc := tokenservice.NewTokenService(&c)
+	authSvc := auth.NewService(repo, tokenSvc)
 	authImpl := transportAuth.New(authSvc)                         // implements mmv1c.AuthServiceHandler
 	authPath, authHandler := mmv1c.NewAuthServiceHandler(authImpl) // HTTP handler + route
 

--- a/core-svc/main.go
+++ b/core-svc/main.go
@@ -35,7 +35,7 @@ func main() {
 	/* -------------- AUTH SERVICE ----------------*/
 	tokenSvc := tokenservice.NewTokenService(&c)
 	authSvc := auth.NewService(repo, tokenSvc)
-	authImpl := transportAuth.New(authSvc)                         // implements mmv1c.AuthServiceHandler
+	authImpl := transportAuth.New(authSvc, tokenSvc)               // implements mmv1c.AuthServiceHandler
 	authPath, authHandler := mmv1c.NewAuthServiceHandler(authImpl) // HTTP handler + route
 
 	/* -------------- ASSIGN HANDLERS ----------------*/

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,26 +1,27 @@
 import 'package:flutter/cupertino.dart';
 import 'package:mobile/screens/login.dart';
-import 'package:mobile/services/auth.service.dart';
-import 'dart:io' as io; // ← add this
+import 'package:mobile/screens/home.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile/notifiers/auth.notifier.dart';
 
-// generated code
-import 'gen/v1/auth.pb.dart';
-import 'gen/v1/auth.connect.client.dart';
+void main() => runApp(const ProviderScope(child: MyApp()));
 
-// connect-dart runtime
-import 'package:connectrpc/io.dart' as connect_io; // dart:io HTTP stack
-import 'package:connectrpc/protobuf.dart'; // ProtoCodec
-import 'package:connectrpc/protocol/connect.dart'
-    as protocol; // Connect protocol
-//  ↑ switch to protocol.grpc / grpc_web if you ever need those
-
-void main() => runApp(const MyApp());
-
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) => CupertinoApp(
-        home: LoginPage(),
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authNotifierProvider);
+    return auth.when(
+      data: (tokens) => CupertinoApp(
+        home: tokens == null ? const LoginPage() : const HomePage(),
+      ),
+      loading: () => const CupertinoApp(
+        home: CupertinoPageScaffold(child: Center(child: CupertinoActivityIndicator())),
+      ),
+      error: (_, __) => const CupertinoApp(
+        home: CupertinoPageScaffold(child: Center(child: Text('Error'))),
+      ),
+    );
+  }
 }

--- a/mobile/lib/notifiers/auth.notifier.dart
+++ b/mobile/lib/notifiers/auth.notifier.dart
@@ -1,6 +1,7 @@
 import 'package:mobile/gen/v1/auth.pb.dart';
 import 'package:mobile/models/auth-tokens.dart';
 import 'package:mobile/services/auth-storage.service.dart';
+import 'package:mobile/services/auth.service.dart';
 import 'package:riverpod/riverpod.dart';
 
 final authNotifierProvider = AsyncNotifierProvider<AuthNotifier, AuthTokens?>(() => AuthNotifier());
@@ -43,16 +44,11 @@ class AuthNotifier extends AsyncNotifier<AuthTokens?> {
   }
 
   Future<AuthTokens?> _refreshToken(String refreshToken) async {
-    // try {
-    //   final client = ref.read(authServiceProvider); // <- gRPC client
-    //   final reply = await client.refresh(RefreshRequest(refreshToken: refreshToken));
-    //   return AuthTokens.fromGrpc(
-    //     accessToken: reply.accessToken,
-    //     refreshToken: reply.refreshToken,
-    //     expiresAtUnix: reply.expiresAt.toInt(),
-    //   );
-    // } catch (_) {
-    //   return null;
-    // }
+    try {
+      final svc = ref.read(authServiceProvider);
+      // Placeholder for refresh call - not implemented on backend
+      await svc.logout();
+    } catch (_) {}
+    return null;
   }
 }

--- a/mobile/lib/notifiers/auth.notifier.dart
+++ b/mobile/lib/notifiers/auth.notifier.dart
@@ -39,6 +39,10 @@ class AuthNotifier extends AsyncNotifier<AuthTokens?> {
   }
 
   Future<void> logout() async {
+    try {
+      final svc = ref.read(authServiceProvider);
+      await svc.logout();
+    } catch (_) {}
     await _storage.clear();
     state = const AsyncData(null);
   }
@@ -46,9 +50,14 @@ class AuthNotifier extends AsyncNotifier<AuthTokens?> {
   Future<AuthTokens?> _refreshToken(String refreshToken) async {
     try {
       final svc = ref.read(authServiceProvider);
-      // Placeholder for refresh call - not implemented on backend
-      await svc.logout();
-    } catch (_) {}
-    return null;
+      final newTokens = await svc.refresh(refreshToken);
+      return AuthTokens.fromGrpc(
+        accessToken: newTokens.accessToken,
+        refreshToken: newTokens.refreshToken,
+        expiresAtUnix: newTokens.expiresAt.toInt(),
+      );
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/mobile/lib/screens/home.dart
+++ b/mobile/lib/screens/home.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/cupertino.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  static Route<void> route() => CupertinoPageRoute(builder: (_) => const HomePage());
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoPageScaffold(
+      child: Center(child: Text('Home')), 
+    );
+  }
+}

--- a/mobile/lib/screens/login.dart
+++ b/mobile/lib/screens/login.dart
@@ -1,17 +1,22 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile/notifiers/auth.notifier.dart';
+import 'package:mobile/screens/home.dart';
 import 'package:mobile/screens/register.dart';
+import 'package:mobile/services/auth.service.dart';
+import 'package:connectrpc/connect.dart';
 
-class LoginPage extends StatefulWidget {
+class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({super.key});
 
   static Route<void> route() =>
       CupertinoPageRoute(builder: (_) => const LoginPage());
 
   @override
-  State<LoginPage> createState() => _LoginPageState();
+  ConsumerState<LoginPage> createState() => _LoginPageState();
 }
 
-class _LoginPageState extends State<LoginPage> {
+class _LoginPageState extends ConsumerState<LoginPage> {
   final _formKey = GlobalKey<FormState>();
   final _emailCtrl = TextEditingController();
   final _pwdCtrl = TextEditingController();
@@ -23,10 +28,21 @@ class _LoginPageState extends State<LoginPage> {
     super.dispose();
   }
 
-  void _submit() {
+  Future<void> _submit() async {
     if (_formKey.currentState!.validate()) {
-      // TODO: wire to auth backend
-      print('login with ${_emailCtrl.text}');
+      final svc = ref.read(authServiceProvider);
+      try {
+        final tokens = await svc.login(_emailCtrl.text, _pwdCtrl.text);
+        await ref.read(authNotifierProvider.notifier).login(tokens);
+        if (context.mounted) {
+          Navigator.of(context).pushAndRemoveUntil(
+            HomePage.route(),
+            (route) => false,
+          );
+        }
+      } on ConnectException catch (e) {
+        print(e.message);
+      }
     }
   }
 

--- a/mobile/lib/services/auth.service.dart
+++ b/mobile/lib/services/auth.service.dart
@@ -5,7 +5,7 @@ import 'package:connectrpc/io.dart' as connect_io;
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as protocol;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:google_sign_in/google_sign_in.dart';
+import 'package:riverpod/riverpod.dart';
 
 import 'package:mobile/gen/v1/auth.connect.client.dart';
 import 'package:mobile/gen/v1/auth.pb.dart';
@@ -24,18 +24,22 @@ class AuthService {
     ),
   );
 
-  Future<String?> Register(String name, String email, String password) async {
-    try {
+  Future<Tokens> login(String email, String password) async {
+    final tokens = await _client.login(LoginRequest(email: email, password: password));
+    return tokens;
+  }
 
-      final tokens = await _client.register(
-          RegisterRequest(name: name, email: email, password: password));
+  Future<Tokens> register(String name, String email, String password) async {
+    final tokens = await _client.register(
+      RegisterRequest(name: name, email: email, password: password),
+    );
+    return tokens;
+  }
 
-      await _storage.write(key: REFRESH_TOKEN_KEY, value: tokens.refreshToken);
-      await _storage.write(key: ACCESS_TOKEN_KEY, value: tokens.accessToken);
-      await _storage.write(key: EXPIRES_AT_KEY, value: tokens.expiresAt.toString());
-    } on ConnectException catch (e) {
-      return e.message;
-    }
-    return null;
+  Future<void> logout() async {
+    await _client.logout(Empty());
+    await _storage.deleteAll();
   }
 }
+
+final authServiceProvider = Provider((ref) => AuthService());

--- a/mobile/lib/services/auth.service.dart
+++ b/mobile/lib/services/auth.service.dart
@@ -36,8 +36,15 @@ class AuthService {
     return tokens;
   }
 
+  Future<Tokens> refresh(String refreshToken) async {
+    final tokens = await _client.refresh(
+      RefreshRequest(refreshToken: refreshToken),
+    );
+    return tokens;
+  }
+
   Future<void> logout() async {
-    await _client.logout(Empty());
+    await _client.logout(LogoutRequest(refreshToken: (await _storage.read(key: 'refreshToken')) ?? ''));
     await _storage.deleteAll();
   }
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   google_sign_in: ^7.1.1
   flutter_secure_storage: ^9.0.0
   riverpod: ^2.6.1
+  flutter_riverpod: ^2.6.1
 
 dev_dependencies:
   flutter_test:

--- a/proto/v1/auth.proto
+++ b/proto/v1/auth.proto
@@ -15,6 +15,10 @@ message Tokens {
     uint64 expires_at = 3;
 }
 
+message RefreshRequest {
+    string refresh_token = 1;
+}
+
 message LogoutRequest {
     string refresh_token = 1;
 }
@@ -36,8 +40,9 @@ message UserProfile {
 service AuthService {
     rpc Login(LoginRequest) returns (Tokens);
     rpc Register(RegisterRequest) returns (Tokens);
+    rpc Refresh(RefreshRequest) returns (Tokens);
 
-    rpc Logout(Empty) returns (Empty);
+    rpc Logout(LogoutRequest) returns (Empty);
 
     rpc Profile(Empty) returns (UserProfile);
 }


### PR DESCRIPTION
## Summary
- generate JWT tokens in token service
- wire login/register to issue tokens via service and transport
- pass token service to main service
- add Riverpod-based auth state tracking on mobile
- implement login, register and protected home page

## Testing
- `go vet ./...` *(fails: no module for generated protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_68837ae9f60c8332bfe46f45608d2410