### PR TITLE
refactor: simplify auth tokens

### DIFF
--- a/core-svc/internal/service/auth/service.go
+++ b/core-svc/internal/service/auth/service.go
@@ -12,17 +12,14 @@ import (
 )
 
 type Tokens struct {
-	RefreshToken string
-	AccessToken  string
-	ExpiresAt    uint64
+	AccessToken string
+	ExpiresAt   uint64
 }
 
 type AuthService interface {
 	Register(ctx context.Context, name, email, password string) (Tokens, error)
 	Login(ctx context.Context, email, password string) (Tokens, error)
-	Refresh(ctx context.Context, refreshToken string) (Tokens, error)
-	Profile(ctx context.Context, id uuid.UUID) (repository.AppUser, error)
-	Logout(ctx context.Context, id uuid.UUID, refreshToken string) error
+	Profile(ctx context.Context, id uuid.UUID) (repository.GetUserByIDRow, error)
 }
 
 type Service struct {
@@ -58,12 +55,7 @@ func (s *Service) Login(ctx context.Context, email, password string) (Tokens, er
 		return Tokens{}, err
 	}
 
-	refresh, _, err := s.Tokens.GenerateRefreshToken(token.AuthTokenData{ID: user.ID})
-	if err != nil {
-		return Tokens{}, err
-	}
-
-	return Tokens{RefreshToken: refresh, AccessToken: access, ExpiresAt: uint64(exp)}, nil
+	return Tokens{AccessToken: access, ExpiresAt: uint64(exp)}, nil
 }
 
 func (s *Service) Register(ctx context.Context, name, email, password string) (Tokens, error) {
@@ -97,54 +89,9 @@ func (s *Service) Register(ctx context.Context, name, email, password string) (T
 		return Tokens{}, err
 	}
 
-	refresh, _, err := s.Tokens.GenerateRefreshToken(token.AuthTokenData{ID: user.ID})
-	if err != nil {
-		return Tokens{}, err
-	}
-
-	return Tokens{RefreshToken: refresh, AccessToken: access, ExpiresAt: uint64(exp)}, nil
+	return Tokens{AccessToken: access, ExpiresAt: uint64(exp)}, nil
 }
 
-func (s *Service) Refresh(ctx context.Context, refreshToken string) (Tokens, error) {
-	if err := s.Tokens.ValidateRefreshToken(refreshToken); err != nil {
-		return Tokens{}, err
-	}
-
-	data, err := s.Tokens.ExtractRefreshTokenData(refreshToken)
-	if err != nil {
-		return Tokens{}, err
-	}
-
-	if _, err := s.Queries.GetUserByID(ctx, data.ID); err != nil {
-		return Tokens{}, err
-	}
-
-	access, exp, err := s.Tokens.GenerateToken(token.AuthTokenData{ID: data.ID})
-	if err != nil {
-		return Tokens{}, err
-	}
-	newRefresh, _, err := s.Tokens.GenerateRefreshToken(token.AuthTokenData{ID: data.ID})
-	if err != nil {
-		return Tokens{}, err
-	}
-	return Tokens{RefreshToken: newRefresh, AccessToken: access, ExpiresAt: uint64(exp)}, nil
-}
-
-func (s *Service) Profile(ctx context.Context, id uuid.UUID) (repository.AppUser, error) {
+func (s *Service) Profile(ctx context.Context, id uuid.UUID) (repository.GetUserByIDRow, error) {
 	return s.Queries.GetUserByID(ctx, id)
-}
-
-func (s *Service) Logout(ctx context.Context, id uuid.UUID, refreshToken string) error {
-	if err := s.Tokens.ValidateRefreshToken(refreshToken); err != nil {
-		return err
-	}
-	data, err := s.Tokens.ExtractRefreshTokenData(refreshToken)
-	if err != nil {
-		return err
-	}
-	if data.ID != id {
-		return fmt.Errorf("token mismatch")
-	}
-	// no-op placeholder for token revocation
-	return nil
 }

--- a/core-svc/internal/transport/auth/handler.go
+++ b/core-svc/internal/transport/auth/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/service/auth"
 	token "github.com/yatochka-dev/motion-mint/core-svc/internal/service/token"
 	"github.com/yatochka-dev/motion-mint/core-svc/internal/transport/interceptor"
@@ -31,9 +30,8 @@ func (h *handler) Login(
 		return nil, err // propagate as Connect error
 	}
 	return connect.NewResponse(&mmv1.Tokens{
-		RefreshToken: tokens.RefreshToken,
-		AccessToken:  tokens.AccessToken,
-		ExpiresAt:    tokens.ExpiresAt,
+		AccessToken: tokens.AccessToken,
+		ExpiresAt:   tokens.ExpiresAt,
 	}), nil
 }
 
@@ -46,24 +44,8 @@ func (h *handler) Register(
 		return nil, err
 	}
 	return connect.NewResponse(&mmv1.Tokens{
-		RefreshToken: tokens.RefreshToken,
-		AccessToken:  tokens.AccessToken,
-		ExpiresAt:    tokens.ExpiresAt,
-	}), nil
-}
-
-func (h *handler) Refresh(
-	ctx context.Context,
-	req *connect.Request[mmv1.RefreshRequest],
-) (*connect.Response[mmv1.Tokens], error) {
-	tokens, err := h.svc.Refresh(ctx, req.Msg.RefreshToken)
-	if err != nil {
-		return nil, err
-	}
-	return connect.NewResponse(&mmv1.Tokens{
-		RefreshToken: tokens.RefreshToken,
-		AccessToken:  tokens.AccessToken,
-		ExpiresAt:    tokens.ExpiresAt,
+		AccessToken: tokens.AccessToken,
+		ExpiresAt:   tokens.ExpiresAt,
 	}), nil
 }
 
@@ -84,18 +66,4 @@ func (h *handler) Profile(
 		Name:  profile.Name,
 		Email: profile.Email,
 	}), nil
-}
-
-func (h *handler) Logout(
-	ctx context.Context,
-	req *connect.Request[mmv1.LogoutRequest],
-) (*connect.Response[mmv1.Empty], error) {
-	id, ok := token.UserIDFromContext(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("missing user"))
-	}
-	if err := h.svc.Logout(ctx, id, req.Msg.RefreshToken); err != nil {
-		return nil, err
-	}
-	return connect.NewResponse(&mmv1.Empty{}), nil
 }

--- a/core-svc/internal/transport/interceptor/auth.go
+++ b/core-svc/internal/transport/interceptor/auth.go
@@ -14,7 +14,7 @@ func Auth(tokens *token.TokenService) connect.UnaryInterceptorFunc {
 		func(next connect.UnaryFunc) connect.UnaryFunc {
 			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 				procedure := req.Spec().Procedure
-				if procedure != "/motionmint.v1.AuthService/Profile" && procedure != "/motionmint.v1.AuthService/Logout" {
+				if procedure != "/motionmint.v1.AuthService/Profile" {
 					return next(ctx, req)
 				}
 				authHeader := req.Header().Get("Authorization")

--- a/mobile/lib/models/auth-tokens.dart
+++ b/mobile/lib/models/auth-tokens.dart
@@ -1,11 +1,9 @@
 class AuthTokens {
   final String accessToken;
-  final String refreshToken;
   final DateTime expiresAt;
 
   AuthTokens({
     required this.accessToken,
-    required this.refreshToken,
     required this.expiresAt,
   });
 
@@ -13,19 +11,16 @@ class AuthTokens {
 
   factory AuthTokens.fromGrpc({
     required String accessToken,
-    required String refreshToken,
     required int expiresAtUnix,
   }) {
     return AuthTokens(
       accessToken: accessToken,
-      refreshToken: refreshToken,
       expiresAt: DateTime.fromMillisecondsSinceEpoch(expiresAtUnix * 1000),
     );
   }
 
   Map<String, String> toStorage() => {
     'accessToken': accessToken,
-    'refreshToken': refreshToken,
     'expiresAt': expiresAt.millisecondsSinceEpoch.toString(),
   };
 
@@ -33,7 +28,6 @@ class AuthTokens {
     if (map.values.any((v) => v == null)) throw Exception('Missing token data');
     return AuthTokens(
       accessToken: map['accessToken']!,
-      refreshToken: map['refreshToken']!,
       expiresAt: DateTime.fromMillisecondsSinceEpoch(
         int.parse(map['expiresAt']!),
       ),

--- a/mobile/lib/notifiers/auth.notifier.dart
+++ b/mobile/lib/notifiers/auth.notifier.dart
@@ -1,7 +1,6 @@
 import 'package:mobile/gen/v1/auth.pb.dart';
 import 'package:mobile/models/auth-tokens.dart';
 import 'package:mobile/services/auth-storage.service.dart';
-import 'package:mobile/services/auth.service.dart';
 import 'package:riverpod/riverpod.dart';
 
 final authNotifierProvider = AsyncNotifierProvider<AuthNotifier, AuthTokens?>(() => AuthNotifier());
@@ -15,11 +14,6 @@ class AuthNotifier extends AsyncNotifier<AuthTokens?> {
     if (tokens == null) return null;
 
     if (tokens.isExpired) {
-      final refreshed = await _refreshToken(tokens.refreshToken);
-      if (refreshed != null) {
-        await _storage.saveTokens(refreshed);
-        return refreshed;
-      }
       await _storage.clear();
       return null;
     }
@@ -30,7 +24,6 @@ class AuthNotifier extends AsyncNotifier<AuthTokens?> {
   Future<void> login(Tokens grpcTokens) async {
     final tokens = AuthTokens.fromGrpc(
       accessToken: grpcTokens.accessToken,
-      refreshToken: grpcTokens.refreshToken,
       expiresAtUnix: grpcTokens.expiresAt.toInt(),
     );
 
@@ -39,25 +32,7 @@ class AuthNotifier extends AsyncNotifier<AuthTokens?> {
   }
 
   Future<void> logout() async {
-    try {
-      final svc = ref.read(authServiceProvider);
-      await svc.logout();
-    } catch (_) {}
     await _storage.clear();
     state = const AsyncData(null);
-  }
-
-  Future<AuthTokens?> _refreshToken(String refreshToken) async {
-    try {
-      final svc = ref.read(authServiceProvider);
-      final newTokens = await svc.refresh(refreshToken);
-      return AuthTokens.fromGrpc(
-        accessToken: newTokens.accessToken,
-        refreshToken: newTokens.refreshToken,
-        expiresAtUnix: newTokens.expiresAt.toInt(),
-      );
-    } catch (_) {
-      return null;
-    }
   }
 }

--- a/mobile/lib/services/auth-storage.service.dart
+++ b/mobile/lib/services/auth-storage.service.dart
@@ -13,21 +13,18 @@ class SecureStorageService {
 
   Future<AuthTokens?> getTokens() async {
     final access = await _storage.read(key: 'accessToken');
-    final refresh = await _storage.read(key: 'refreshToken');
     final expiry = await _storage.read(key: 'expiresAt');
 
-    if (access == null || refresh == null || expiry == null) return null;
+    if (access == null || expiry == null) return null;
 
     return AuthTokens(
       accessToken: access,
-      refreshToken: refresh,
       expiresAt: DateTime.fromMillisecondsSinceEpoch(int.parse(expiry)),
     );
   }
 
   Future<void> clear() async {
     await _storage.delete(key: 'accessToken');
-    await _storage.delete(key: 'refreshToken');
     await _storage.delete(key: 'expiresAt');
   }
 }

--- a/mobile/lib/services/auth.service.dart
+++ b/mobile/lib/services/auth.service.dart
@@ -4,17 +4,13 @@ import 'package:connectrpc/connect.dart';
 import 'package:connectrpc/io.dart' as connect_io;
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as protocol;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:riverpod/riverpod.dart';
 
 import 'package:mobile/gen/v1/auth.connect.client.dart';
 import 'package:mobile/gen/v1/auth.pb.dart';
 import 'package:mobile/shared/constants.dart';
-import 'package:mobile/shared/storage.dart';
 
 class AuthService {
-  final _storage = const FlutterSecureStorage();
-
   // Use the constructor like in the pub.dev example
   late final AuthServiceClient _client = AuthServiceClient(
     protocol.Transport(
@@ -34,18 +30,6 @@ class AuthService {
       RegisterRequest(name: name, email: email, password: password),
     );
     return tokens;
-  }
-
-  Future<Tokens> refresh(String refreshToken) async {
-    final tokens = await _client.refresh(
-      RefreshRequest(refreshToken: refreshToken),
-    );
-    return tokens;
-  }
-
-  Future<void> logout() async {
-    await _client.logout(LogoutRequest(refreshToken: (await _storage.read(key: 'refreshToken')) ?? ''));
-    await _storage.deleteAll();
   }
 }
 

--- a/proto/v1/auth.proto
+++ b/proto/v1/auth.proto
@@ -10,18 +10,10 @@ message LoginRequest {
 }
 
 message Tokens {
-    string refresh_token = 1;
-    string access_token = 2;
-    uint64 expires_at = 3;
+    string access_token = 1;
+    uint64 expires_at = 2;
 }
 
-message RefreshRequest {
-    string refresh_token = 1;
-}
-
-message LogoutRequest {
-    string refresh_token = 1;
-}
 message Empty {}
 
 message RegisterRequest {
@@ -40,10 +32,6 @@ message UserProfile {
 service AuthService {
     rpc Login(LoginRequest) returns (Tokens);
     rpc Register(RegisterRequest) returns (Tokens);
-    rpc Refresh(RefreshRequest) returns (Tokens);
-
-    rpc Logout(LogoutRequest) returns (Empty);
-
     rpc Profile(Empty) returns (UserProfile);
 }
 


### PR DESCRIPTION
## Summary
- remove refresh token support from auth protocol and services
- switch to 3-day access tokens with email/password auth
- update mobile client storage and notifier for single-token flow

## Testing
- `go test ./...`
- `dart format mobile/lib/services/auth.service.dart mobile/lib/models/auth-tokens.dart mobile/lib/services/auth-storage.service.dart mobile/lib/notifiers/auth.notifier.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f235357b4833280fa9a4d7ec6c073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access tokens now have an extended validity period (72 hours).
* **Bug Fixes**
  * Simplified authentication flow by removing refresh token and logout functionality.
* **Refactor**
  * Login and registration now return only access tokens and expiration times.
  * All references to refresh tokens have been removed from the app and API.
* **Chores**
  * Updated protocol definitions and internal logic to match the new authentication approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->